### PR TITLE
Split up carthage_main_setup and allow for passing in args

### DIFF
--- a/carthage/dependency_injection.py
+++ b/carthage/dependency_injection.py
@@ -681,7 +681,8 @@ Return the first injector in our parent chain containing *k* or None if there is
         elif self.claimed_by() is None:
             claim_str = "claimed by dead object"
         else: claim_str = f'claimed by {repr(self.claimed_by())}'
-        return f'<{self.__class__.__name__} {claim_str}>'
+        closed_str = 'CLOSED ' if self.closed else ''
+        return f'<{closed_str}{self.__class__.__name__} {claim_str}>'
 
     @property
     def is_claimed(self):

--- a/carthage/machine.py
+++ b/carthage/machine.py
@@ -499,7 +499,7 @@ class BaseCustomization(SetupTaskMixin, AsyncInjectable):
                  'name', 'full_name',
                  'apply_customization'):
             return getattr(self.host, a)
-        raise AttributeError
+        raise AttributeError(f"'{self}' has no attribute '{a}'")
 
     def __repr__(self):
         return f"<{self.__class__.__name__} description:\"{self.description}\" for {self.host.name}>"

--- a/carthage/machine.py
+++ b/carthage/machine.py
@@ -414,14 +414,14 @@ class Machine(AsyncInjectable, SshMixin):
                     self.sshfs_path = tempfile.mkdtemp(dir = self.config_layout.state_dir, prefix=self.name, suffix = "sshfs")
                     self.sshfs_process = await self.sshfs_process_factory()
                     for x in range(5):
-                        await asyncio.sleep(0.4)
-                        if os.path.exists(os.path.join(
-                                self.sshfs_path, "run")):
-                            break
                         alive, *rest = self.sshfs_process.process.is_alive()
                         if not alive:
                             await self.sshfs_process
                             raise RuntimeError #I'd expect that to have happened from an sh exit error already
+                        if os.path.exists(os.path.join(
+                                self.sshfs_path, "run")):
+                            break
+                        await asyncio.sleep(0.4)
                     else:
                         raise TimeoutError("sshfs failed to mount")
             yield self.sshfs_path

--- a/carthage/machine.py
+++ b/carthage/machine.py
@@ -379,6 +379,16 @@ class Machine(AsyncInjectable, SshMixin):
         meth = getattr(customization, method)
         return await meth()
 
+    async def sshfs_process_factory(self):
+        return sh.sshfs(
+            '-o' 'ssh_command='+" ".join(
+                str(self.ssh).split()[:-1]) ,
+            f'{self.ip_address}:/',
+            self.sshfs_path,
+            '-f',
+            _bg = True,
+            _bg_exc = False)
+
     @contextlib.asynccontextmanager
     async def filesystem_access(self):
         '''
@@ -402,14 +412,7 @@ class Machine(AsyncInjectable, SshMixin):
             async with self.sshfs_lock:
                 if self.sshfs_count == 1:
                     self.sshfs_path = tempfile.mkdtemp(dir = self.config_layout.state_dir, prefix=self.name, suffix = "sshfs")
-                    self.sshfs_process = sh.sshfs(
-                        '-o' 'ssh_command='+" ".join(
-                            str(self.ssh).split()[:-1]) ,
-                        f'{self.ip_address}:/',
-                        self.sshfs_path,
-                        '-f',
-                        _bg = True,
-                        _bg_exc = False)
+                    self.sshfs_process = await self.sshfs_process_factory()
                     for x in range(5):
                         await asyncio.sleep(0.4)
                         if os.path.exists(os.path.join(

--- a/carthage/modeling/implementation.py
+++ b/carthage/modeling/implementation.py
@@ -471,12 +471,12 @@ class ModelingContainer(InjectableModelType):
 
         if not isinstance(state.value, ModelingContainer): return
         val = state.value
+        outer_key = None
         if hasattr(val, '__provides_dependencies_for__'):
-            outer_key = None
             for outer_key in val.__provides_dependencies_for__:
                 if isinstance(outer_key.target, ModelingContainer) and len(outer_key.constraints) > 0:
                     break
-            if outer_key is None or len(outer_key.constraints) == 0: return
+        if outer_key is None or len(outer_key.constraints) == 0: return
         to_propagate = combine_mro_mapping(val, ModelingContainer, '__container_propagations__')
         to_propagate.update(val.__container_propagations__)
         for k, info in to_propagate.items():

--- a/carthage/setup_tasks.py
+++ b/carthage/setup_tasks.py
@@ -331,6 +331,7 @@ class SetupTaskMixin:
                         self.logger_for().info(f"Running {t.description} task for {self}")
                         await ainjector(t, self)
                         dependency_last_run = time.time()
+                        self.logger_for().info(f"Finished running {t.description} task for {self} at {dependency_last_run}")
                     else:
                         self.logger_for().info(f'Would run {t.description} task for {self}')
                 except SkipSetupTask: pass


### PR DESCRIPTION
The goal is to allow utility programs (such as 'devstack') to handle
their own argument parsing while still getting the standard logging
configuration and configfile parsing.

So we can optionally pass in the args we got from our own argparser
(that follows the protocol from add_carthage_arguments).