### PR TITLE
Move resolution of outer_key so that it can be found (as None)

### DIFF
--- a/carthage/modeling/implementation.py
+++ b/carthage/modeling/implementation.py
@@ -471,12 +471,12 @@ class ModelingContainer(InjectableModelType):
 
         if not isinstance(state.value, ModelingContainer): return
         val = state.value
+        outer_key = None
         if hasattr(val, '__provides_dependencies_for__'):
-            outer_key = None
             for outer_key in val.__provides_dependencies_for__:
                 if isinstance(outer_key.target, ModelingContainer) and len(outer_key.constraints) > 0:
                     break
-            if outer_key is None or len(outer_key.constraints) == 0: return
+        if outer_key is None or len(outer_key.constraints) == 0: return
         to_propagate = combine_mro_mapping(val, ModelingContainer, '__container_propagations__')
         to_propagate.update(val.__container_propagations__)
         for k, info in to_propagate.items():


### PR DESCRIPTION
I'm not entirely confident this is what we want, but I am confident that we can do better than

```
  File "/root/project/carthage/carthage/modeling/implementation.py", line 484, in _integrate_containment                                                                                                                   
    propagate_provider(k, v, options)                                                                                                                                                                                      
  File "/root/project/carthage/carthage/modeling/implementation.py", line 436, in propagate_provider                                                                                                                       
    outer_constraints = outer_key.constraints                                                                                                                                                                              
NameError: free variable 'outer_key' referenced before assignment in enclosing scope                                                                                                                                       
```