### PR TITLE
Use -P to set empty passphrase instead of empty string to stdin

### DIFF
--- a/carthage/ssh.py
+++ b/carthage/ssh.py
@@ -62,10 +62,10 @@ class SshKey(AsyncInjectable, SetupTaskMixin):
 
     @setup_task('gen-key')
     async def generate_key(self):
-        no_passphrase = io.StringIO("")
         os.makedirs(self.config_layout.state_dir, exist_ok = True)
         await sh.ssh_keygen(f = self.key_path,
-                            _in = no_passphrase,
+                            N = '',
+                            _in = None,
                             _bg = True,
                             _bg_exc = False)
 


### PR DESCRIPTION
This was motivated by an issue generating keys on Windows Subsystem
for Linux (WSL).  For reasons I didn't have time to explore, on WSL,
carthage.sh.ssh-keygen invokes and blocks on ssh-askpass even when
given _in = StringIO('').

I am assuming that -P is consistent across versions of ssh-keygen.  If
so, this is cleaner than using stdin independently of debugging the
issue with WSL (for the specific case of empty passphrase).