### PR TITLE
Use a more useful filename for compile()

### DIFF
--- a/carthage/console.py
+++ b/carthage/console.py
@@ -56,6 +56,10 @@ class CarthageConsole(code.InteractiveConsole):
 
     def exec_resource(self, pkg, resource):
         res_str = pkg_resources.resource_string(pkg, resource)
+        try:
+            fn = pkg_resources.resource_filename(pkg, resource)
+        except:
+            raise
         exec(compile(res_str, resource, mode = "exec"),  self.locals)
         
     def __init__(self, locals=None, extra_locals=None):


### PR DESCRIPTION
As written, the script will get marked as resources/runner_console.py,
leading to very confusing output in the debugger.

I'm confident in the try: part but not sure what's best if a filename
is unavailable.  There's always '<string>' but I didn't look to see if
pdb can read from resources.

Based on your feedback I'll update the patch and the message