### PR TITLE
First cut at deployment module

### DIFF
--- a/carthage/__init__.py
+++ b/carthage/__init__.py
@@ -33,6 +33,9 @@ from .kvstore import KvStore, KvConsistency,AssignmentsExhausted, persistent_see
 __all__ += ['persistent_seed_path']
 
 
+from . import deployment
+from .deployment import  find_deployables, DeployableFinder
+__all__ += ['find_deployables', 'DeployableFinder']
 
 from .network import Network, NetworkConfig, MacStore, V4Config, V4Pool
 
@@ -93,6 +96,7 @@ __all__ += ['CarthagePlugin']
 base_injector = carthage.dependency_injection.Injector()
 base_injector.claim("base injector")
 carthage.config.inject_config(base_injector)
+base_injector.add_provider(deployment.MachineDeployableFinder)
 base_injector.add_provider(ssh.SshKey)
 base_injector.add_provider(ssh.AuthorizedKeysFile)
 base_injector.add_provider(asyncio.get_event_loop(), close=False)

--- a/carthage/console.py
+++ b/carthage/console.py
@@ -170,7 +170,7 @@ class CarthageConsole(code.InteractiveConsole):
         if isinstance(obj, collections.abc.Coroutine):
             self.history_num += 1
             num = self.history_num
-            future = asyncio.ensure_future(obj, loop=self.loop)
+            future = asyncio.run_coroutine_threadsafe(obj, loop=self.loop)
             future.add_done_callback(future_callback)
             print(f'[{num}]: async {obj.__name__}')
             self.history[num] = future

--- a/carthage/dependency_injection/base.py
+++ b/carthage/dependency_injection/base.py
@@ -417,6 +417,9 @@ Return the first injector in our parent chain containing *k* or None if there is
         if isinstance(predicate, list):
             constraints = predicate
             predicate = filter_for_constraints
+        if isinstance(stop_at, AsyncInjector):
+            stop_at = stop_at.injector
+        assert isinstance(stop_at, (Injector, type(None)))
         if stop_at == self:
             result = {}  # stop here
         elif stop_at and not self.parent_injector:

--- a/carthage/dependency_injection/base.py
+++ b/carthage/dependency_injection/base.py
@@ -442,7 +442,7 @@ Return the first injector in our parent chain containing *k* or None if there is
             if res is not None:
                 yield k, res
 
-    def inspect(self, *,key_filter=None, include_parent:bool = False):
+    def inspect(self, *, key_filter=None, include_parent:bool = False):
         '''
         Inspect the contents of this injector.
         This is a generator yielding key, :class:`~InjectedDependencyInspector` pairs for each dependency provided by the injector.
@@ -1368,6 +1368,15 @@ class InjectorXrefMarkerMeta(type):
     def __repr__(self):
         return f'injector_xref({self.injectable_key}, {self.target_key})'
 
+    def __hash__(self):
+        try:return hash(self.injectable_key)+hash(self.target_key)
+        except AttributeError:
+            return hash(self.target_key)
+
+    def __eq__(self, other):
+        if getattr(self, 'injectable_key', None) != getattr(other, 'injectable_key', None): return False
+        if self.target_key != other.target_key: return False
+        return True
 
 class InjectorXrefMarker(AsyncInjectable, metaclass=InjectorXrefMarkerMeta):
 

--- a/carthage/deployment.py
+++ b/carthage/deployment.py
@@ -1,0 +1,150 @@
+# Copyright (C) 2023, Hadron Industries, Inc.
+# Carthage is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License version 3
+# as published by the Free Software Foundation. It is distributed
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the file
+# LICENSE for details.
+
+import asyncio
+import enum
+import typing
+from .dependency_injection import *
+
+__all__ = []
+
+class DeletionPolicy(enum.Enum):
+
+    '''
+    A policy for how to handle  object removals. There are typically two policies:
+
+    * *destroy_policy*: what to do with a :class:`Deployment` when a layout is destroyed
+
+    * *orphan_policy*: What to do with a model that used to be created by a given layout but is no longer contained in that layout.
+
+    By default *destroy_policy* is *DELETE* and *orphan_policy* is *RETAIN*.
+    '''
+
+    #: Retain the deployable without  any diagnostic.
+    RETAIN = enum.auto()
+
+    #: Warn about the deployable
+    WARN = enum.auto()
+
+    #: Delete the object using default recursion rules for that object.
+    DELETE = enum.auto()
+
+__all__ += ['DeletionPolicy']
+
+#: An injection key representing the policy to be applied to objects
+#created by a layout when that layout is destroyed.
+destroy_policy = InjectionKey(DeletionPolicy, policy='destroy')
+
+__all__ += ['destroy_policy']
+
+
+#: An injection key describing the policy for how to handle orphaned
+#deployables--deployables that were created by the layout but are no
+#longer included in it.
+orphan_policy = InjectionKey(DeletionPolicy, policy='orphan')
+
+__all__ += ['orphan_policy']
+
+@typing.runtime_checkable
+class Deployable(typing.Protocol):
+
+
+    '''An object that can be deployed either by calling :meth:`find_or_create` or :meth:`async_become_ready`.
+
+    While the object may not be fully deployed when :meth:`find_or_create` returns, it should be fully deployed when :meth:`async_ready` returns for the first time.
+    '''
+
+    async def find_or_create(self):
+        '''Find or create this deployable. If this succeeds the deployable exists, but may not be fully deployed.
+        '''
+        raise NotImplementedError
+
+    async def find(self):
+        '''Find whether object exists.
+        If this returns True, the object must exist.  If this returns falsy, then if *id* or *mob* is set on the object,  it exists.  There is a bit of divergence in how :meth:`find` returns.  See :func:`find_deployable` for a more uniform way to call this function.
+        Should not raise simply because the object does not exist.
+        '''
+        raise NotImplementedError
+
+
+__all__ += ['Deployable']
+
+class DeployableFinder(AsyncInjectable):
+
+    '''
+    A :class:`Deployable` represents some infrastructure that can be created by an Carthage object.
+    There are multiple conventions for finding the available *Deployables*.  For example :class:`~carthage.machine.Machine` are typically found by searching for all ``InjectionKey(Machine)`` with a *host* constraint.
+
+    a :class:`DeployableFinder` knows how to find some deployables in the injector hierarchy.
+
+    DeployableFinders have a *name* typically set in a subclass.  It is an error to instantiate a subclass of DeployableFinder that is not refined enough to have a name.
+
+    The default class injection key arranges that if a *DeployableFinder* is added to an injector, it will provide ``InjectionKey(DeployableFinder, name=name)``.  So, to instantiate all the DeployableFinders it is sufficient to::
+
+        ainjector.filter_instantiate_async(DeployableFinder, ['name'])
+
+    '''
+
+    #: The plugin name under which a DeployableFinder is registered
+    name = None
+
+    async def find(self, stop_at):
+        '''
+        Returns an iterable of :class:`Deployable` objects. Thes objects should be instantiated in a not-ready state (instantiating InjectionKeys with ``_ready=False``.
+
+        :param stop_at: The scope of the injector hierarchy to search.  See :meth:`carthage.Injector.filter` for documentation.
+        
+        '''
+        raise NotImplementedError
+
+    def __init__(self, **kwargs):
+        if self.name is None:
+            raise TypeError(f'{self.__class__} is abstract: it has no DeployableFinder name')
+        super().__init__(**kwargs)
+
+    @classmethod
+    def default_class_injection_key(cls):
+        if cls.name is None:
+            return super().default_class_injection_key()
+        return InjectionKey(DeployableFinder, name=cls.name)
+
+__all__ += ['DeployableFinder']
+
+class MachineDeployableFinder(DeployableFinder):
+
+    '''
+    A :class:`DeployableFinder` that finds :class:`Machines <carthage.machine.Machine>`.
+
+    Usage::
+        injector.add_provider(MachineDeployableFinder)
+
+    '''
+
+    name = 'machine'
+
+    async def find(self, stop_at):
+        from .machine import Machine
+        result = await self.ainjector.filter_instantiate_async(Machine, ['host'], stop_at=stop_at, ready=False)
+        return [x[1] for x in result]
+
+@inject(
+    ainjector=AsyncInjector,
+    )
+async def find_deployables(*, ainjector,
+                           stop_at=None):
+    finder_filter = await ainjector.filter_instantiate_async(DeployableFinder, ['name'],  stop_at=stop_at, ready=True)
+    result_ids = set()
+    results = []
+    for _, finder in finder_filter:
+        for r in await finder.find(stop_at=stop_at):
+            if id(r) in result_ids: continue
+            results.append(r)
+            result_ids.add(id(r))
+    return results
+
+__all__ += ['find_deployables']

--- a/carthage/deployment.py
+++ b/carthage/deployment.py
@@ -84,6 +84,23 @@ __all__ += ['DryRun']
 class IgnoreDeployable(Exception):
     '''Raised to indicate that a deployable should be ignored
     '''
+
+class FailureList(list):
+
+    '''This is a list with the additional behavior that if a
+    deployable is passed into __contains__, then if a member is a
+    DeploymentFailure with deployable set to the deployable,
+    __contains__ will return true.  This allows syntax like::
+
+        if deployable in result.failures:
+            # do stuff
+
+    '''
+
+    def __contains__(self, item):
+        if isinstance(item, Deployable):
+            return any(x.deployable == item for x in self)
+        return super.__contains__(item)
     
     
 @dataclasses.dataclass(frozen=True)
@@ -114,8 +131,8 @@ __all__ += ['DeploymentFailure']
 class DeploymentResult:
 
     successes: list[Deployable] = dataclasses.field(default_factory=lambda: [])
-    failures: list[DeploymentFailure] = dataclasses.field(default_factory=lambda: [])
-    dependency_failures: list[DeploymentFailure] = dataclasses.field(default_factory=lambda: [])
+    failures: FailureList[DeploymentFailure] = dataclasses.field(default_factory=lambda: FailureList())
+    dependency_failures: FailureList[DeploymentFailure] = dataclasses.field(default_factory=lambda: FailureList())
 
     #: A Deployable can be not found either if it is readonly=True or
     #not found on a delete

--- a/carthage/machine.py
+++ b/carthage/machine.py
@@ -248,6 +248,9 @@ class NetworkedModel(ResolvableModel):
 
     network_links: typing.Mapping[str, carthage.network.NetworkLink]
 
+    #: A class of :class:`~carthage.network.TechnologySpecificNetwork` that will be instantiated for the links on this NetworkedModel.
+    network_implementation_class: carthage.network.TechnologySpecificNetwork = None
+
     async def resolve_networking(self, force: bool = False):
         '''
             Adds all :class:`carthage.network.NetworkLink` objects specified in the :class:`carthage.network.NetworkConfig`  to the network_links property.
@@ -278,7 +281,20 @@ class NetworkedModel(ResolvableModel):
     async def resolve_model(self, force:bool=False):
         await self.resolve_networking(force=force)
         return await super().resolve_model(force=force)
-    
+
+    async def dynamic_dependencies(self):
+        '''See :func:`carthage.deployment.Deployable.dynamic_dependencies` for documentation.
+        Returns technology specific networks for links where that is possible.
+        '''
+        if not self.network_implementation_class: return []
+        await self.resolve_networking()
+        results = []
+        network_class = self.network_implementation_class
+        for l in self.network_links.values():
+            if l.local_type: continue
+            instance = await l.net.access_by(network_class, ready=False)
+            results.append(instance)
+        return results
 
 class AbstractMachineModel(NetworkedModel):
 

--- a/carthage/modeling/decorators.py
+++ b/carthage/modeling/decorators.py
@@ -222,6 +222,13 @@ class FlagClearDecorator(ModelingDecoratorWrapper):
         state.flags &= ~self.flag
 
 
+def no_inject_name(val=None, /):
+    def wrap(v):
+        return FlagClearDecorator(v, NSFlags.instantiate_on_access|NSFlags.inject_by_name)
+    if val is not None:
+        return wrap(val)
+    else: return wrap
+    
 def no_instantiate():
     def wrapper(val):
         return FlagClearDecorator(val, NSFlags.instantiate_on_access)
@@ -400,7 +407,7 @@ class wrap_base_customization:
 
 
 __all__ = ["ModelingDecoratorWrapper", "provides", 'dynamic_name',
-           'injector_access', 'no_instantiate',
+           'injector_access', 'no_inject_name', 'no_instantiate',
            'allow_multiple', 'no_close',
            'globally_unique_key',
            'MachineMixin', 'machine_mixin',

--- a/carthage/network/base.py
+++ b/carthage/network/base.py
@@ -174,7 +174,7 @@ class Network(AsyncInjectable):
         pool.new_assignments()
         pool.assignment_loop(self.network_links)
         
-    async def access_by(self, cls: TechnologySpecificNetwork):
+    async def access_by(self, cls: TechnologySpecificNetwork, ready=None):
         '''Request a view of *self* using *cls* as a technology-specific lens.
 
         :return: The instance of *cls* for accessing this network
@@ -184,12 +184,12 @@ class Network(AsyncInjectable):
         instance = None
         if (cls not in self.ainjector) and self.vlan_id is not None:
             try:
-                instance = await self.ainjector.get_instance_async(InjectionKey(cls, vlan_id=self.vlan_id))
+                instance = await self.ainjector.get_instance_async(InjectionKey(cls, vlan_id=self.vlan_id, _ready=ready))
                 self.ainjector.add_provider(instance)
             except KeyError:
                 pass
         if not instance:
-            instance = await self.ainjector.get_instance_async(cls)
+            instance = await self.ainjector.get_instance_async(InjectionKey(cls, _ready=ready))
         assert cls in self.ainjector, \
             f"It looks like {cls} was not registered with add_provider with allow_multiple set to True"
         if instance not in self.technology_networks:

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -1,0 +1,127 @@
+# Copyright (C) 2023, Hadron Industries, Inc.
+# Carthage is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License version 3
+# as published by the Free Software Foundation. It is distributed
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the file
+# LICENSE for details.
+
+import pytest
+
+from carthage import *
+from carthage.modeling import *
+from carthage.deployment import *
+from carthage.pytest import *
+
+class MockDeployable(InjectableModel, SetupTaskMixin, AsyncInjectable):
+
+    name = None
+
+    readonly=False
+    @setup_task("Find or create")
+    async def find_or_create(self):
+        if res := await self.find():
+            return res
+        await self.do_create()
+        if not await self.find():
+            raise LookupError('Object failed to be found after creation')
+
+    @find_or_create.check_completed()
+    async def find_or_create(self):
+        return await self.find()
+
+    async def find(self):
+        return self in deployed_deployables
+
+    async def do_create(self):
+        deployed_deployables.add(self)
+
+    async def delete(self):
+        deployed_deployables.remove(self)
+
+    def __str__(self):
+        return 'Deployable:'+self.name
+
+    def __repr__(self):
+        return f'{self.__class__.__name__}(name={self.name})'
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        if cls.name:
+            propagate_key(InjectionKey(MockDeployable, deployable_name=cls.name), cls)
+
+
+class MockDeployableFinder(DeployableFinder):
+    name = 'mock'
+
+    async def find(self, ainjector):
+        result = await ainjector.filter_instantiate_async(
+            MockDeployable, lambda k:True,
+            stop_at=ainjector,
+            ready=False)
+        return [x[1] for x in result]
+
+deployed_deployables = set()
+
+@pytest.fixture()
+def ainjector(ainjector):
+    deployed_deployables.clear()
+    ainjector.add_provider(MockDeployableFinder)
+    return ainjector
+
+    
+    
+@async_test
+async def test_run_deployment_simple(ainjector):
+    class layout(CarthageLayout):
+
+        @inject(ci=InjectionKey("continuous_integration"))
+        class good_software(MockDeployable):
+            name = 'good software'
+
+        class devops(Enclave):
+            domain = 'devops'
+
+            @propagate_key(InjectionKey('continuous_integration', _globally_unique=True))
+            class continuous_integration(MockDeployable):
+
+                name ='continuous_integration'
+
+    ainjector.add_provider(layout)
+    l = await ainjector.get_instance_async(CarthageLayout)
+    ainjector = l.ainjector
+    deployables = await ainjector(find_deployables)
+    assert len(deployables) == 2
+    result = await ainjector(run_deployment)
+    assert l.good_software in result.successes
+    assert l.devops.continuous_integration in result.successes
+    assert len(result.successes)==2
+    assert result.is_successful()
+
+@async_test
+async def test_failure_detection(ainjector):
+    class layout(CarthageLayout):
+
+        @inject(not_buggy=InjectionKey("software_without_bugs"))
+        class good_software(MockDeployable):
+            name = 'good software'
+
+        @propagate_key(InjectionKey("software_without_bugs", _globally_unique=True))
+        class software_without_bugs(MockDeployable):
+
+            name ='software without bugs'
+
+            async def do_create(self):
+                raise NotImplementedError("We're not quite there yet.")
+                
+
+    ainjector.add_provider(layout)
+    l = await ainjector.get_instance_async(CarthageLayout)
+    ainjector = l.ainjector
+    result = await ainjector(run_deployment, dry_run=True)
+    assert len(result.successes) == 2
+    assert l.software_without_bugs in result.successes # At least for dry run
+    result_full_run = await ainjector(
+        run_deployment, deployables=result)
+    assert l.software_without_bugs in [x.deployable for x in result_full_run.failures]
+    assert l.good_software in [x.deployable for x in result_full_run.dependency_failures]

--- a/tests/test_podman.py
+++ b/tests/test_podman.py
@@ -347,7 +347,7 @@ async def test_podman_pod_network(layout_fixture):
     try:
         try: await layout.net_pod.container.machine.async_become_ready()
         except InjectionFailed as e:
-            if isinstance(e.__cause__, NotImplementedError):
+            if isinstance(e.__cause__.__cause__, NotImplementedError):
                 pytest.xfail('Podman is too old')
             raise
         async with layout.net_pod.container.machine.machine_running():


### PR DESCRIPTION
This is ready for @fxdgear to take a look at the general direction.
There's still a lot of work to do.
Provide way to find all the objects that should be deployed:

* Deployable is a new protocol for what deployable objects should have as an interface

* DeployableFinder is a plugin mechanism to find all the deployables

* MachineDeployableFinder finds all the machines.

* find_deployables is a top level interface to use the DeployableFinder mechanism.