### PR TITLE
Allow setting config.vmware.proxy to a URL for use as a HTTP proxy.

### DIFF
--- a/carthage/vmware/credentials.py
+++ b/carthage/vmware/credentials.py
@@ -13,6 +13,7 @@ class CredentialsSchema(ConfigSchema, prefix="vmware"):
     hostname: str
     username: str = "{vault:secret/password/{vmware.hostname}:username}"
     password: str = "{vault:secret/password/{vmware.hostname}:password}"
+    proxy: str = None
     validate_certs: bool = False
 
 


### PR DESCRIPTION
Example: http://proxy.corp.com:3128 .  It would be nice for this to support http_proxy and similar environment variables, but it doesn't. It also supports only HTTP proxies, not HTTPS.