### PR TITLE
Add NET_ADMIN and NET_RAW to support debugging

### DIFF
--- a/carthage/podman/base.py
+++ b/carthage/podman/base.py
@@ -316,7 +316,6 @@ An OCI container implemented using ``podman``.  While it is possible to set up a
 
     def _podman_create_options(self):
         options = []
-        options = options + ['--cap-add', 'NET_ADMIN', '--cap-add', 'NET_RAW']
         options.append('--restart=' + self.podman_restart)
         if self.oci_interactive:
             options.append('-i')
@@ -333,6 +332,8 @@ An OCI container implemented using ``podman``.  While it is possible to set up a
         for m in self.mounts:
             options.append(podman_mount_option(self.injector, m))
         options.extend(self.podman_options)
+        if '--privileged' not in options:
+            options.extend(['--cap-add', 'NET_ADMIN', '--cap-add', 'NET_RAW'])
         return options
 
     async def delete(self, force=True, volumes=True):

--- a/carthage/podman/base.py
+++ b/carthage/podman/base.py
@@ -316,6 +316,7 @@ An OCI container implemented using ``podman``.  While it is possible to set up a
 
     def _podman_create_options(self):
         options = []
+        options = options + ['--cap-add', 'NET_ADMIN', '--cap-add', 'NET_RAW']
         options.append('--restart=' + self.podman_restart)
         if self.oci_interactive:
             options.append('-i')


### PR DESCRIPTION
This makes debugging dramatically better.

An argument against it is that it exposes more OS surface to the container and that it shouldn't be default.

A better solution might be something like
filter_instantiate(OciCapability), with default capabilities taken from a configvar?  But I want to get opinions before implementing.