### PR TITLE
Fix capitalization on Entrypoint

### DIFF
--- a/carthage/podman/base.py
+++ b/carthage/podman/base.py
@@ -452,8 +452,8 @@ class PodmanImage(OciImage, SetupTaskMixin):
         config = image_info['Config']
         if not self.oci_image_command and 'Cmd' in config:
             self.oci_image_command = config['Cmd']
-        if not self.oci_image_entry_point and 'EntryPoint' in config:
-            self.oci_image_entry_point = config['EntryPoint']
+        if not self.oci_image_entry_point and 'Entrypoint' in config:
+            self.oci_image_entry_point = config['Entrypoint']
         self.base_image_info = image_info
         self.last_layer = self.base_image_info['Id']
 


### PR DESCRIPTION
My impression from https://github.com/opencontainers/image-spec/blob/main/schema/config-schema.json#L47 is that this is just a typo and that there's no need to recognize alternate capitalization