### PR TITLE
Podman remote host

### DIFF
--- a/.github/aws.yml
+++ b/.github/aws.yml
@@ -1,0 +1,13 @@
+plugins:
+- https://github.com/hadron/carthage-base
+- https://github.com/hadron/carthage-aws
+authorized_keys: /dev/null
+aws:
+  access_key_id: ${AWS_ACCESS_KEY}
+  secret_access_key: ${AWS_SECRET_KEY}
+  profile: ${CARTHAGE_TEST_AWS_PROFILE}
+  region: us-east-1
+  vpc_name: test_vpc
+  vpc_dns_hostnames_enabled: true
+base_dir: /tmp/carthage-base
+checkout_dir: /tmp/carthage-base/checkout

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -125,7 +125,7 @@ jobs:
       run: |
         # It looks like podman create fails the first time with a resource busy
         podman run --rm debian:latest sleep 1 || true
-        pytest-3 tests/test_podman.py --carthage-config=.github/aws.yml --remote-container-host -v -s --log-cli-level=info
+        pytest-3 -k 'not no_rootless' tests/test_podman.py --carthage-config=.github/aws.yml --remote-container-host -v -s --log-cli-level=info
 
   github_release:
     runs-on: ubuntu-22.04

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -111,11 +111,15 @@ jobs:
     - name: install_dependencies_and_carthage
       run: |
         apt update
-        apt -y install python3 python3-pip python3-pytest git
+         apt -y install python3 python3-pip python3-pytest git sshfs podman
         pip3 install --break-system-packages dist/*whl
         carthage --plugin carthage.podman --plugin https://github.com/hadron/carthage-aws generate_requirements >requirements.txt
         pip3 install --break-system-packages -r requirements.txt
         carthage --plugin carthage.podman --plugin https://github.com/hadron/carthage-aws install_dependencies
+
+#    - uses: mxschmitt/action-tmate@v3
+#      with:
+#        detached: true
 
     - name: Test Carthage
       run: |

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -7,7 +7,7 @@ permissions:
   contents: read
   
 env:
-  core_dependencies: python3-requests python3-yaml python3-mako python3-sh python3-lmdb
+  core_dependencies: python3-requests python3-yaml python3-mako python3-sh python3-lmdb git
   run_tests: --carthage-config=build_test/authorized.yml -k "not no_rootless and not test_pki and not requires_podman_pod"
 jobs:
   build_python_dist:
@@ -88,12 +88,47 @@ jobs:
         podman run --rm debian:latest sleep 1 || true
         pytest-3 ${{env.run_tests}} tests
 
+  test_remote_podman:
+    runs-on: ubuntu-22.04
+    needs: build_python_dist
+    container:
+      image: 'debian:bookworm'
+      options: --privileged
+    env:
+      AWS_ACCESS_KEY: ${{secrets.AWS_ACCESS_KEY}}
+      AWS_SECRET_KEY: ${{secrets.AWS_SECRET_KEY}}
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: download_dist
+      uses: actions/download-artifact@v3
+      with:
+        name: Python Distributions
+        path: dist
+
+    - name: install_dependencies_and_carthage
+      run: |
+        apt update
+        apt -y install python3 python3-pip python3-pytest git
+        pip3 install --break-system-packages dist/*whl
+        carthage --plugin carthage.podman --plugin https://github.com/hadron/carthage-aws generate_requirements >requirements.txt
+        pip3 install --break-system-packages -r requirements.txt
+        carthage --plugin carthage.podman --plugin https://github.com/hadron/carthage-aws install_dependencies
+
+    - name: Test Carthage
+      run: |
+        # It looks like podman create fails the first time with a resource busy
+        podman run --rm debian:latest sleep 1 || true
+        pytest-3 tests/test_podman.py --carthage-config=.github/aws.yml --remote-container-host -v -s --log-cli-level=info
+
   github_release:
     runs-on: ubuntu-22.04
     permissions:
       contents: write
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [build_python_dist, test_python_dist]
+    needs: [build_python_dist, test_python_dist, test_remote_podman]
     
     steps:
     - name: Checkout code

--- a/carthage/become_privileged.py
+++ b/carthage/become_privileged.py
@@ -11,6 +11,8 @@ import typing
 import carthage.machine
 from . import machine, sh
 from .utils import memoproperty
+from .ssh import SshAgent
+
 __all__ = []
 
 #: List of sftp-server locations
@@ -75,7 +77,7 @@ async def sshfs_sftp_finder(
     :param prefix: Command inserted between the become_privileged_command and sftp invocation.  Can be used to enter the right namespace.
 
     '''
-    
+    agent = await machine.ainjector.get_instance_async(SshAgent)
     sftp_command_list = become_privileged_command + [
         '/bin/sh', '-c',
         f"'for sftp in {' '.join(sftp_server_locations)} ; do test -x $sftp && exec {prefix} $sftp; done'"]
@@ -87,5 +89,5 @@ async def sshfs_sftp_finder(
         f'{carthage.machine.ssh_user_addr(machine)}:/',
         sshfs_path,
         '-f',
-        )
+        _env=agent.agent_environ)
 

--- a/carthage/carthage_plugin.yml
+++ b/carthage/carthage_plugin.yml
@@ -12,6 +12,7 @@ dependencies:
     pypi: lmdb
   - deb: python3-netifaces
     pypi: netifaces
+  - deb: git
   - deb: socat
   - deb: systemd-container
   - deb: libvirt-clients

--- a/carthage/container.py
+++ b/carthage/container.py
@@ -302,6 +302,18 @@ class Container(Machine, SetupTaskMixin):
         return sh.nsenter.bake("-t" + self.container_leader, "-C", "-m", "-n", "-u", "-i", "-p",
                                _env=self._environment())
 
+    def run_command(self, *args, _bg=True,
+                          _bg_exc=False, _user=None,
+                          **kwargs):
+        if _user is None:
+            _user = self.runas_user
+        if _user != 'root':
+            raise NotImplementedError('Not currently supported for runas_user to be different than root')
+        if self.running:
+            return self.shell(*args, **kwargs)
+        else:
+            return self.container_command(*args, _bg=_bg, _bg_exc=_bg_exc, **kwargs)
+        
     def _environment(self, networking=False):
         env = os.environ.copy()
         env['DEBIAN_FRONTEND'] = 'noninteractive'
@@ -341,6 +353,5 @@ class Container(Machine, SetupTaskMixin):
 
     def _apply_to_filesystem_customization(self, customization):
         customization.path = self.volume.path
-        customization.run_command = self.container_command
 
 __all__ = ['container_volume', 'container_image', 'Container']

--- a/carthage/machine.py
+++ b/carthage/machine.py
@@ -242,7 +242,11 @@ A marker in a call to :meth:`rsync` indicating that *p* should be copied to or f
             logger.debug(f'{self.name} is ssh_online')
             break
         if not online:
-            raise TimeoutError("{} not online".format(self.ip_address)) from last_error
+            if isinstance(last_error, sh.TimeoutException):
+                raise TimeoutError("{} not online".format(self._address)) from last_error
+            else:
+                raise TimeoutError(f'{self.ip_address} not online: {last_error}') from last_error
+            
 
     def ssh_recompute(self, *args):
         try:

--- a/carthage/machine.py
+++ b/carthage/machine.py
@@ -758,7 +758,7 @@ class BaseCustomization(SetupTaskMixin, AsyncInjectable):
 
     def __getattr__(self, a):
         if a in ('ssh', 'ip_address', 'start_machine', 'stop_machine',
-                 "filesystem_access",
+                 'filesystem_access', 'run_command',
                  'model',
                  'name', 'ansible_inventory_name',
                  'machine_running', 'running',

--- a/carthage/machine.py
+++ b/carthage/machine.py
@@ -176,8 +176,8 @@ class SshMixin:
         else:
             ssh_agent = self.injector.get_instance(carthage.ssh.SshAgent)
             key_options = tuple()
-        options = self.ssh_options + ('-oUserKnownHostsFile=' +
-                                      os.path.join(self.config_layout.state_dir, 'ssh_known_hosts'),)
+        options = self.ssh_options + ('-F' +
+                                      str(ssh_agent.ssh_config),)
         if ssh_origin_container is not None:
             ip_address = self.ip_address
             ssh_origin_container.done_future().add_done_callback(self.ssh_recompute)

--- a/carthage/machine.py
+++ b/carthage/machine.py
@@ -633,6 +633,7 @@ it works like :meth:`carthage.container.Container.container_command` and is used
     async def sshfs_process_factory(self, user):
         if user != self.ssh_login_user:
             raise ValueError(f'{self.__class__.__qualname__} cannot set up filesystem access when runas_user != ssh_login_user')
+        agent = await self.ainjector.get_instance_async(SshAgent)
         return sh.sshfs(
             '-o' 'ssh_command=' + " ".join(
                 str(self.ssh).split()[:-1]),
@@ -640,7 +641,8 @@ it works like :meth:`carthage.container.Container.container_command` and is used
             self.sshfs_path,
             '-f',
             _bg=True,
-            _bg_exc=False)
+            _bg_exc=False,
+            _env = agent.agent_environ)
 
     @contextlib.asynccontextmanager
     async def filesystem_access(self, user=None):

--- a/carthage/podman/__init__.py
+++ b/carthage/podman/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C)  2022, 2023, Hadron Industries, Inc.
+# Copyright (C)  2022, 2023, 2024, Hadron Industries, Inc.
 # Carthage is free software; you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License version 3
 # as published by the Free Software Foundation. It is distributed
@@ -16,6 +16,10 @@ __all__ += ['PodmanPod', 'PodmanContainer', 'PodmanImage',
 from .modeling import PodmanPodModel, PodmanImageModel, ContainerfileImageModel
 
 __all__ += ['PodmanPodModel', 'PodmanImageModel', 'ContainerfileImageModel']
+
+from .container_host import LocalPodmanContainerHost, RemotePodmanHost, podman_container_host
+
+__all__ += ['LocalPodmanContainerHost', 'RemotePodmanHost', 'podman_container_host']
 
 
 @carthage.inject(injector=carthage.Injector)

--- a/carthage/podman/base.py
+++ b/carthage/podman/base.py
@@ -313,10 +313,14 @@ An OCI container implemented using ``podman``.  While it is possible to set up a
             self.running = False
             await super().stop_machine()
 
-    def container_exec(self, *args):
+    def container_exec(self, *args, _user=None):
         '''
 'Execute a command in a running container and return stdout.  This function intentionally has a differentname than :meth:`carthage.container.Container.container_command` because that method does not expect the container to be running.
 '''
+        if _user is None:
+            _user = self.runas_user
+        if _user != 'root':
+            raise NotImplementedError('only can run as root for now')
         result = self.podman(
             'container', 'exec',
             self.full_name,

--- a/carthage/podman/base.py
+++ b/carthage/podman/base.py
@@ -191,6 +191,7 @@ An OCI container implemented using ``podman``.  While it is possible to set up a
     def ansible_inventory_overrides(self):
         return dict(
             ansible_connection='containers.podman.podman',
+            ansible_podman_extra_args=self.container_host.extra_args,
             ansible_pipelining=False,
             ansible_host=self.full_name,
         )

--- a/carthage/podman/base.py
+++ b/carthage/podman/base.py
@@ -325,6 +325,8 @@ An OCI container implemented using ``podman``.  While it is possible to set up a
 
     #: An alias to be more compatible with :class:`carthage.container.Container`
     shell = container_exec
+    #: container_exec meets the run_command interface
+    run_command = container_exec
 
     def _apply_to_filesystem_customization(self, customization):
         @contextlib.asynccontextmanager
@@ -334,7 +336,6 @@ An OCI container implemented using ``podman``.  While it is possible to set up a
                 yield
             return
         customization.customization_context = customization_context()
-        customization.run_command = self.container_exec
 
     def filesystem_access(self, user='root'):
         assert self.container_host, 'call self.find first'

--- a/carthage/podman/base.py
+++ b/carthage/podman/base.py
@@ -102,7 +102,6 @@ class PodmanPod(OciPod, PodmanNetworkMixin, carthage.machine.NetworkedModel):
     async def find(self):
         if not self.container_host:
             await self.ainjector(find_container_host, self)
-        await self.container_host.start_container_host()
         if self.id:
             inspect_arg = self.id
         else:
@@ -209,7 +208,6 @@ An OCI container implemented using ``podman``.  While it is possible to set up a
     async def find(self):
         if not self.container_host:
             await self.ainjector(find_container_host, self)
-        await self.container_host.start_container_host()
         try:
             result = await self.podman(
                 'container', 'inspect', self.full_name,
@@ -421,7 +419,6 @@ class PodmanImage(OciImage, SetupTaskMixin):
     async def pull_base_image(self):
         if not self.container_host:
             await self.ainjector(find_container_host, self)
-        await self.container_host.start_container_host()
         if isinstance(self.base_image, OciImage):
             await self.base_image.async_become_ready()
             base_image = self.base_image.oci_image_tag
@@ -449,7 +446,6 @@ class PodmanImage(OciImage, SetupTaskMixin):
     async def find(self):
         if not self.container_host:
             await self.ainjector(find_container_host, self)
-        await self.container_host.start_container_host()
         if self.id:
             to_find = self.id
             self.oci_read_only = True
@@ -732,7 +728,6 @@ class ContainerfileImage(OciImage):
     async def find(self):
         if not self.container_host:
             await self.ainjector(find_container_host, self)
-        await self.container_host.start_container_host()
         try: inspect_result = await self.container_host.podman(
                 'image', 'inspect',
                 self.oci_image_tag, _log=False)
@@ -787,7 +782,6 @@ class PodmanNetwork(TechnologySpecificNetwork, OciManaged):
     async def find(self):
         if not self.container_host:
             await self.ainjector(find_container_host, self)
-            await self.container_host.start_container_host()
         try:
             inspect_result = await self.podman(
                 'network', 'inspect', self.network.name, _log=False)

--- a/carthage/podman/base.py
+++ b/carthage/podman/base.py
@@ -80,12 +80,12 @@ class PodmanNetworkMixin:
                 return ['--network', 'container:'+network_namespace.id]
             return []           # Joining a pod
         return await self._network_options() # Creating our own namespace
-           
+
     async def resolve_networking(self, force:bool = False):
         await super().resolve_networking(force=force)
         for net in set(map( lambda l:l.net, self.network_links.values())):
             net.assign_addresses()
-            
+
 @inject(
     podman_pod_options=InjectionKey('podman_pod_options', _optional=NotPresent),
 )
@@ -143,7 +143,7 @@ class PodmanPod(OciPod, PodmanNetworkMixin, carthage.machine.NetworkedModel):
 
 __all__ += ['PodmanPod']
 
-   
+
 
 @inject_autokwargs(
     oci_container_image=InjectionKey(oci_container_image, _optional=NotPresent),
@@ -174,7 +174,7 @@ An OCI container implemented using ``podman``.  While it is possible to set up a
             return self.model.podman_options
         except AttributeError:
             return []
-        
+
 
     @memoproperty
     def ssh_options(self):
@@ -228,7 +228,7 @@ An OCI container implemented using ``podman``.  While it is possible to set up a
         except Exception as e:
             raise ValueError(f'Invalid ISO string: {self.container_info["Created"]}')
 
-            
+
     async def do_create(self):
         image = self.oci_container_image
         if isinstance(image, OciImage):
@@ -577,8 +577,8 @@ class PodmanImage(OciImage, SetupTaskMixin):
         path = Path(config.output_dir)/"podman_image"/self.oci_image_tag.replace('/','_')
         path.mkdir(exist_ok=True, parents=True)
         return path
-    
-                            
+
+
 
 __all__ += ['PodmanImage']
 podman_image_volume_key = InjectionKey('carthage.podman/image_volume')
@@ -640,8 +640,8 @@ class ImageLayerTask(TaskWrapperBase):
     def stamp(self):
         #Overridden if an image_layer_task is assigned as a class property
         return self.customization.__name__
-    
-    
+
+
 @inject_autokwargs(
     config_layout=ConfigLayout,
     podman_options=InjectionKey('podman_options', _optional=NotPresent),
@@ -683,8 +683,8 @@ class ContainerfileImage(OciImage):
             self.setup_tasks.sort(key=lambda t: 1 if t.func == OciManaged.find_or_create.func else 0)
             self.container_context = self.output_path
         self.injector.add_provider(InjectionKey("podman_log"), self.stamp_path/'podman.log')
-                                   
-            
+
+
 
 
     @memoproperty
@@ -712,8 +712,8 @@ class ContainerfileImage(OciImage):
         source_mtime = self.container_context_mtime(self.source_container_context)
         if source_mtime > last_run: return False
         return False
-    
-        
+
+
     async def do_create(self):
         options = await self._build_options()
         return await self.container_host.podman(
@@ -752,8 +752,8 @@ class ContainerfileImage(OciImage):
             stat = p.stat()
             if stat.st_mtime >mtime: mtime = stat.st_mtime
         return mtime
-    
-    
+
+
 
     async def _build_options(self):
         options = []
@@ -779,7 +779,7 @@ class PodmanNetwork(TechnologySpecificNetwork, OciManaged):
     @property
     def podman(self):
         return self.container_host.podman
-    
+
     async def find(self):
         if not self.container_host:
             await self.ainjector(find_container_host, self)
@@ -794,7 +794,7 @@ class PodmanNetwork(TechnologySpecificNetwork, OciManaged):
         except (KeyError, ValueError):
             logger.error('Unable to understand network inspection result: %s', info)
             raise NotImplementedError('Podman too old')
-        
+
 
     async def do_create(self):
         options = ['-d', 'bridge']
@@ -822,7 +822,7 @@ class PodmanNetwork(TechnologySpecificNetwork, OciManaged):
         await self.podman(
             'network', 'rm', *force_options,
             self.network.name)
-        
+
     def link_options(self, link):
         def safe(s):
             assert ',' not in s

--- a/carthage/podman/container_host.py
+++ b/carthage/podman/container_host.py
@@ -35,7 +35,7 @@ class PodmanContainerHost(AsyncInjectable):
     @memoproperty
     def podman_log(self):
         return self.injector.get_instance(InjectionKey("podman_log", _optional=True))
-    
+
     def podman(self, *args,
                _bg=True, _bg_exc=True):
         raise NotImplementedError
@@ -62,11 +62,11 @@ class PodmanContainerHost(AsyncInjectable):
         '''Extra arguments to pass to podman from ansible plugin.
         '''
         return ''
-    
+
 class LocalPodmanContainerHost(PodmanContainerHost):
 
-        
-    
+
+
     @contextlib.asynccontextmanager
     async def filesystem_access(self, container):
         result = await self.podman(
@@ -127,7 +127,7 @@ class RemotePodmanHost(PodmanContainerHost):
         self.sshfs_path = None
         self.sshfs_process = None
         self.sshfs_lock = asyncio.Lock()
-        
+
 
     def __repr__(self):
         try:
@@ -185,7 +185,7 @@ class RemotePodmanHost(PodmanContainerHost):
                 raise TimeoutError('container host failed to become ready')
             
             self.local_socket = local_socket
-        
+
 
     async def stop_container_host(self):
         async with self._operation_lock:
@@ -196,12 +196,12 @@ class RemotePodmanHost(PodmanContainerHost):
 
     def out_cb(self, data):
         logger.debug('%r: %s', self, data)
-        
+
     def process_done(self, *args):
         logger.info('%r: podman terminated', self)
         self.process = None
         self.local_socket = None
-        
+
     def podman(self, *args, _log=True,
                _bg=True, _bg_exc=False):
         options = {}
@@ -291,7 +291,7 @@ class RemotePodmanHost(PodmanContainerHost):
     def extra_args(self):
         '''Tell Ansible about container_host'''
         return f'--url=unix://{self.local_socket}'
-    
+
     tar_volume_context = LocalPodmanContainerHost.tar_volume_context
 __all__ += ['RemotePodmanHost']
 
@@ -323,4 +323,3 @@ async def find_container_host(target, *, container_host):
     assert isinstance(container_host, Machine), 'container_host must be a PodmanContainerHost or machine'
     target.container_host = await ainjector(RemotePodmanHost, machine=container_host)
     return
-    

--- a/carthage/podman/container_host.py
+++ b/carthage/podman/container_host.py
@@ -57,6 +57,12 @@ class PodmanContainerHost(AsyncInjectable):
     async def start_container_host(self):
         pass
 
+    @property
+    def extra_args(self):
+        '''Extra arguments to pass to podman from ansible plugin.
+        '''
+        return ''
+    
 class LocalPodmanContainerHost(PodmanContainerHost):
 
         
@@ -191,7 +197,7 @@ class RemotePodmanHost(PodmanContainerHost):
             options['_err_to_out'] = True
             #breakpoint()
         return sh.podman(
-                f'--url=unix://{self.local_socket}',
+            self.extra_args,
                 *args,
                 **options)
 
@@ -268,6 +274,11 @@ class RemotePodmanHost(PodmanContainerHost):
             return []
         return machine.become_privileged_command(user)
 
+    @property
+    def extra_args(self):
+        '''Tell Ansible about container_host'''
+        return f'--url=unix://{self.local_socket}'
+    
     tar_volume_context = LocalPodmanContainerHost.tar_volume_context
 __all__ += ['RemotePodmanHost']
 

--- a/carthage/podman/container_host.py
+++ b/carthage/podman/container_host.py
@@ -1,0 +1,303 @@
+# Copyright (C)  2022, 2023, 2024, Hadron Industries, Inc.
+# Carthage is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License version 3
+# as published by the Free Software Foundation. It is distributed
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the file
+# LICENSE for details.
+from __future__ import annotations
+import asyncio
+import contextlib
+import datetime
+import json
+import logging
+import os
+from pathlib import Path
+import tempfile
+import shutil
+import uuid
+import dateutil.parser
+import carthage.machine
+from carthage.dependency_injection import *
+from .. import sh, ConfigLayout, become_privileged
+from ..machine import AbstractMachineModel, Machine
+from ..utils import memoproperty
+from ..oci import *
+
+__all__ = []
+
+logger = logging.getLogger('carthage.podman')
+
+
+
+class PodmanContainerHost(AsyncInjectable):
+
+    @memoproperty
+    def podman_log(self):
+        return self.injector.get_instance(InjectionKey("podman_log", _optional=True))
+    
+    def podman(self, *args,
+               _bg=True, _bg_exc=True):
+        raise NotImplementedError
+
+    async def filesystem_access(self, container):
+        raise NotImplementedError
+
+    async def tar_volume_context(self, volume):
+        '''
+        An asynchronous context manager that tars up a volume and provides a path to that tar file usable in ``podman import``.  Typical usage::
+
+            async with container_host.tar_volume_context(container_image) as path:
+                await container_host.podman('import', path)
+
+        On local systems this manages temporary directories.  For remote container hosts, this manages to get the tar file to the remote system and clean up later.
+        '''
+        raise NotImplementedError
+
+    async def start_container_host(self):
+        pass
+
+class LocalPodmanContainerHost(PodmanContainerHost):
+
+        
+    
+    @contextlib.asynccontextmanager
+    async def filesystem_access(self, container):
+        result = await self.podman(
+            'container', 'mount',
+            container,
+            _bg=True, _bg_exc=False, _log=False)
+        try:
+            path = str(result).strip()
+            yield Path(path)
+        finally:
+            pass  # Perhaps we should unmount, but we'd need a refcount to do that.
+
+    def podman(self, *args,
+               _bg=True, _bg_exc=False, _log=True):
+        options = {}
+        if _log and self.podman_log:
+            options['_out']=str(self.podman_log)
+            options['_err_to_out'] = True
+        return sh.podman(
+            *args,
+            _bg=_bg, _bg_exc=_bg_exc,
+            _encoding='utf-8',
+            **options)
+
+    @contextlib.asynccontextmanager
+    async def tar_volume_context(self, volume):
+        assert hasattr(volume, 'path')
+        with tempfile.TemporaryDirectory() as path_raw:
+            path = Path(path_raw)
+            await sh.tar(
+                "-C", str(volume.path),
+                "--xattrs",
+                "--xattrs-include=*.*",
+                "-czf",
+                str(path / "container.tar.gz"),
+                ".",
+                _bg=True,
+                _bg_exc=False)
+            yield path / 'container.tar.gz'
+
+__all__ += ['LocalPodmanContainerHost']
+
+class RemotePodmanHost(PodmanContainerHost):
+
+    machine: Machine = None
+    user: str = None
+
+    def __init__(self, machine, user=None, **kwargs):
+        super().__init__(**kwargs)
+        self.machine = machine
+        if user is None:
+            user = machine.runas_user
+        self.user = user
+        self._operation_lock = asyncio.Lock()
+        self.process = None
+        self.local_socket = None
+        self.sshfs_count = 0
+        self.sshfs_path = None
+        self.sshfs_process = None
+        self.sshfs_lock = asyncio.Lock()
+        
+
+    def __repr__(self):
+        try:
+            return f'<PodmanContainerHost on {self.machine.name}'
+        except Exception:
+            return '<PodmanContainerHost>'
+
+    async def start_container_host(self):
+        machine = self.machine
+        await machine.start_machine()
+        if self.local_socket:
+            return
+        async with self._operation_lock:
+            become_privileged_command = []
+            if hasattr(machine, 'become_privileged_command'):
+                become_privileged_command = machine.become_privileged_command(self.user)
+            #xxx we should probe for home directory
+            if self.user == 'root':
+                home_directory = '/root'
+            else:
+                home_directory = '/home/'+self.user
+            socket_directory = home_directory+'/.carthage/podman_sockets'
+            socket = socket_directory+'/'+str(uuid.uuid4())
+            await machine.run_command(
+            'mkdir', '-p', socket_directory,
+            _user=self.user)
+            config = machine.injector(ConfigLayout)
+            state_dir = Path(config.state_dir)
+            local_socket = state_dir/'local_podman_sockets'/machine.name
+            local_socket.parent.mkdir(exist_ok=True, parents=True)
+            with contextlib.suppress(OSError):
+                local_socket.unlink()
+            self.process = machine.ssh(
+                f'-L{local_socket}:{socket}',
+                *become_privileged_command,
+            'podman', 'system', 'service',
+                '--timeout', '90',
+                f'unix://{socket}',
+                _bg=True, _bg_exc=False,
+                _done=self.process_done)
+            for i in range(5):
+                try:
+                    await sh.podman('info')
+                    break
+                except sh.ErrorReturnCode:
+                    await asyncio.sleep(0.5)
+                    
+            self.local_socket = local_socket
+        
+
+    async def stop_container_host(self):
+        async with self._operation_lock:
+            if self.process is not None:
+                self.process.terminate()
+                self.local_socket = None
+                self.process = None
+
+    def process_done(self, *args):
+        self.process = None
+        self.local_socket = None
+        
+    def podman(self, *args, _log=True,
+               _bg=True, _bg_exc=False):
+        options = {}
+        if _log and self.podman_log:
+            options['_out']=str(self.podman_log)
+            options['_err_to_out'] = True
+            #breakpoint()
+        return sh.podman(
+                f'--url=unix://{self.local_socket}',
+                *args,
+                **options)
+
+    @contextlib.asynccontextmanager
+    async def filesystem_access(self, container):
+        prefix = []
+        if self.user != 'root':
+            prefix ='podman unshare'
+        res = await self.machine.run_command(
+            *prefix.split(' '),
+            'podman',
+            'container',
+            'mount',
+            container)
+        remote_path_str = str(res.stdout, 'utf-8').strip()
+        remote_path_str = os.path.relpath(remote_path_str,'/')
+        # Copied and modified from Machine.filesystem_access.
+        # Refactoring so there is more shared code did not work out on my first try.
+        self.sshfs_count += 1
+        try:
+            # Argument for correctness of locking.  The goal of
+            # sshfs_lock is to make sure that two callers are not both
+            # trying to spin up sshfs at the same time.  The lock is
+            # never held when sshfs_count is < 1, so it will not block
+            # when the coroutine that actually starts sshfs acquires
+            # the lock.  Therefore the startup can actually proceed.
+            # It would be equally correct to grab the lock before
+            # incrementing sshfs_count, but more difficult to
+            # implement because the lock must be released by time of
+            # yield so other callers can concurrently access the filesystem.
+            async with self.sshfs_lock:
+                if self.sshfs_count == 1:
+                    self.sshfs_path = tempfile.mkdtemp(
+                        dir=self.machine.config_layout.state_dir, prefix=self.machine.name, suffix="sshfs_"+self.user)
+                    self.sshfs_process = await become_privileged.sshfs_sftp_finder(
+                        machine=self.machine,
+                        prefix=prefix,
+                        sshfs_path=self.sshfs_path,
+                        become_privileged_command=self.become_privileged_command
+                    )
+                    for x in range(5):
+                        alive, *rest = self.sshfs_process.process.is_alive()
+                        if not alive:
+                            await self.sshfs_process
+                            raise RuntimeError  # I'd expect that to have happened from an sh exit error already
+                        if os.path.exists(os.path.join(
+                                self.sshfs_path, remote_path_str)):
+                            break
+                        await asyncio.sleep(0.4)
+                    else:
+                        raise TimeoutError("sshfs failed to mount")
+            yield Path(self.sshfs_path)/remote_path_str
+        finally:
+            self.sshfs_count -= 1
+            if self.sshfs_count <= 0:
+                self.sshfs_count = 0
+                try:
+                    self.sshfs_process.process.terminate()
+                except BaseException:
+                    pass
+                dir = self.sshfs_path
+                self.sshfs_path = None
+                self.sshfs_process = None
+                await asyncio.sleep(0.2)
+                with contextlib.suppress(OSError):
+                    if dir:
+                        os.rmdir(dir)
+
+    @property
+    def become_privileged_command(self):
+        user = self.user
+        machine = self.machine
+        if not hasattr(machine, 'become_privileged_command'):
+            return []
+        return machine.become_privileged_command(user)
+
+    tar_volume_context = LocalPodmanContainerHost.tar_volume_context
+__all__ += ['RemotePodmanHost']
+
+#:InjectionKey to look up a container host.  Can either be a
+#:class:`PodmanContainerHost` or a :class:`Machine`.
+podman_container_host = InjectionKey('carthage.podman/container_host')
+
+
+__all__ += ['podman_container_host']
+
+@inject(container_host=InjectionKey(podman_container_host, _optional=True))
+async def find_container_host(target, *, container_host):
+    '''
+    Set *target.container_host* to the appropriate container host.
+    '''
+    if target.container_host:
+        return
+    if container_host is None:
+        class_name = target.__class__.__module__+'.'+target.__class__.__qualname__
+        logger.warning('%s instance %s does not declare a container host; using local podman', class_name, repr(target))
+        target.container_host = await target.ainjector(LocalPodmanContainerHost)
+        return
+    if isinstance(container_host, PodmanContainerHost):
+        target.container_host = container_host
+        return
+    if isinstance(container_host, AbstractMachineModel):
+        ainjector = container_host.injector.get_instance(AsyncInjector)
+        container_host = await ainjector.get_instance_async(Machine)
+        
+    assert isinstance(container_host, Machine), 'container_host must be a PodmanContainerHost or machine'
+    target.container_host = await ainjector(RemotePodmanHost, machine=container_host)
+    return
+    

--- a/carthage/pytest_plugin.py
+++ b/carthage/pytest_plugin.py
@@ -64,6 +64,8 @@ def pytest_addoption(parser):
     group = parser.getgroup("Carthage", "Carthage Continuous Integration Options")
     group.addoption('--carthage-config',
                     type=argparse.FileType('rt'),
+                    default=[],
+                    action='append',
                     help="Specify yaml carthage config; this configuration file describes where to put VMs and where to find hadron-operations.  It is not the test configuration for individual tests.  This option is typically used on the controller and not alongside --carthage-json on the system under test.",
                     metavar="file")
     group.addoption('--carthage-json',
@@ -89,12 +91,12 @@ def pytest_configure(config):
         logging.getLogger('sh').setLevel(logging.ERROR)
         logging.getLogger('carthage.sh').propagate = False
         carthage_config = config.getoption('carthage_config')
-    if carthage_config:
+    for c in carthage_config:
         config_layout = base_injector(ConfigLayout)
         try:
-            config_layout.load_yaml(carthage_config)
+            config_layout.load_yaml(c)
         finally:
-            carthage_config.close()
+            c.close()
     test_params_yaml = config.getoption('test_parameters')
     if test_params_yaml:
         config.carthage_test_parameters = yaml.load(test_params_yaml)

--- a/carthage/sh.py
+++ b/carthage/sh.py
@@ -14,12 +14,10 @@ import sh as _sh
 Monkey patch the sh module to include __await__.
 Also, by default for commands retrieved through this module set _bg=True and _bg_exc=False
 '''
-Command = _sh.Command
+_sh_context = _sh(_bg=True, _bg_exc=False)
 
 def __getattr__(name):
-    val = getattr(_sh, name)
-    if isinstance(val, Command):
-        val = val.bake(_bg=True, _bg_exc=False)
+    val = getattr(_sh_context, name)
     globals()[name] = val
     return val
 

--- a/carthage/ssh.py
+++ b/carthage/ssh.py
@@ -170,7 +170,9 @@ async def rsync(*args, config_layout,
         if ssh_options:
             ssh_options = list(ssh_options)
 
-        ssh_options.extend(['-oUserKnownHostsFile=' + str(config_layout.state_dir) + "/ssh_known_hosts"])
+        ssh_options.extend(['-F'+str(ssh_agent.ssh_config)])
+        if key:
+            ssh_options.extend(['-i'+str(key.key_path)])
         ssh_options = " ".join(ssh_options)
         rsync_opts = ['-e', 'ssh ' + ssh_options]
         if rsync_command:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,11 @@ from carthage.pytest import *
 
 pytest_plugins = ('carthage.pytest_plugin',)
 
+def pytest_addoption(parser):
+    group = parser.getgroup('podman', 'Podman test options')
+    group.addoption('--remote-container-host',
+                    action='store_true',
+                    help='Use remote container host in AWS for Podman Carthage tests')
 
 @pytest.mark.no_rootless
 @pytest.fixture(scope='session')

--- a/tests/podman_remote_host.py
+++ b/tests/podman_remote_host.py
@@ -1,0 +1,64 @@
+# Copyright (C) 2024, Hadron Industries, Inc.
+# Carthage is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License version 3
+# as published by the Free Software Foundation. It is distributed
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the file
+# LICENSE for details.
+
+'''
+A container host running in AWS for the podman tests.  In its own separate file because of all the dependencies.
+'''
+from carthage import *
+from carthage.modeling import *
+from carthage import become_privileged
+from carthage import cloud_init as ci
+import carthage.ansible
+
+try:
+    import carthage_aws as aws
+except ImportError:
+    raise ImportError('For --remote-container-host to work, your carthage config needs to reference the AWS plugin and include valid AWS account and VPC information.')
+
+class container_host(MachineModel):
+    add_provider(machine_implementation_key, dependency_quote(aws.AwsVm))
+    add_provider(ssh_jump_host, dependency_quote(None))
+    ssh_login_user = 'admin'
+    runas_user = 'admin'
+    machine_mixins = (become_privileged.BecomePrivilegedMixin, carthage.ansible.AnsibleIpAddressMixin)
+    cloud_init = True
+    add_provider(ci.DisableRootPlugin)
+    aws_instance_type = 't3.medium'
+    aws_availability_zone = 'us-east-1a'
+
+    add_provider(InjectionKey('aws_ami'), aws.image_provider(owner=aws.debian_ami_owner, name='debian-12-amd64-*'))
+
+    @provides('aws_net')
+    class aws_net(NetworkModel):
+        v4_config = V4Config(
+            network='192.168.100.0/24')
+
+        class ssh_sg(aws.AwsSecurityGroup):
+            name = 'ssh'
+            ingress_rules = (
+                aws.SgRule(
+                    cidr='0.0.0.0/0',
+                    port=22),
+                )
+        aws_security_groups = ['ssh']
+        
+    
+    class net_config(NetworkConfigModel):
+        add('eth0', mac=None, net=aws_net)
+        
+    class install_podman(FilesystemCustomization):
+        runas_user = 'root'
+
+        @setup_task("Install podman software")
+        async def do_install(self):
+            await self.run_command('apt', 'update')
+            await self.run_command('apt', '-y',
+                                   'install',
+                                   'podman', 'containers-storage')
+            await self.run_command('loginctl', 'enable-linger', 'admin')
+            

--- a/tests/podman_remote_host.py
+++ b/tests/podman_remote_host.py
@@ -20,7 +20,7 @@ try:
 except ImportError:
     raise ImportError('For --remote-container-host to work, your carthage config needs to reference the AWS plugin and include valid AWS account and VPC information.')
 
-class container_host(MachineModel):
+class container_host(MachineModel, AsyncInjectable):
     add_provider(machine_implementation_key, dependency_quote(aws.AwsVm))
     add_provider(ssh_jump_host, dependency_quote(None))
     ssh_login_user = 'admin'

--- a/tests/test_podman.py
+++ b/tests/test_podman.py
@@ -48,6 +48,7 @@ def ainjector(enable_podman, pytestconfig, loop):
     container_host_instance = ainjector.injector.get_instance(InjectionKey(podman_container_host, _ready=False))
     try:
         host_machine = container_host_instance.machine
+        logger.info('Deleting %s', host_machine)
         loop.run_until_complete(host_machine.ainjector(host_machine.delete))
         # AsyncRequired if the machine was never set up
         # AttributeError if it's a LocalPodmanContainerHost

--- a/tests/test_podman.py
+++ b/tests/test_podman.py
@@ -49,6 +49,18 @@ def ainjector(enable_podman, pytestconfig, loop):
         host_machine = loop.run_until_complete(container_host_instance.ainjector.get_instance_async(InjectionKey(Machine, _ready=False)))
     except KeyError:
         host_machine = None
+    try:
+        if host_machine:
+            loop.run_until_complete(host_machine.async_become_ready())
+    except Exception as e:
+        logger.exception('Error bringing container_host to ready:')
+        try:
+            logger.info('Deleting %s', host_machine)
+            loop.run_until_complete(host_machine.delete())
+            host_machine = None
+        except Exception:
+            logger.exception('Error deleting container_host')
+        raise e
     yield ainjector
     if host_machine:
         logger.info('Deleting %s', host_machine)


### PR DESCRIPTION
Add support for podman containers managed remotely.
Expects layouts to set podman_container_host to either a MachineModel, Machine, or PodmanContainerHost.