### PR TITLE
Use sha256 for the default mako_task hash function

### DIFF
--- a/carthage/setup_tasks.py
+++ b/carthage/setup_tasks.py
@@ -19,6 +19,7 @@ import typing
 import sys
 import shutil
 import weakref
+import hashlib
 import importlib.resources
 from pathlib import Path
 import carthage
@@ -724,9 +725,10 @@ If the template has a def called *hash*, this def will be rendered with the same
             template = self.lookup.get_template(self.template)
             if template.has_def('hash'):
                 hash_template = template.get_def("hash")
-                return hash_template.render(instance=instance, **kwargs)
+                s = hash_template.render(instance=instance, **kwargs)
             else:
-                return template.render(instance=instance, **kwargs)
+                s = template.render(instance=instance, **kwargs)
+            return hashlib.sha256(s.encode()).hexdigest()
         self.template = template
         if output is None:
             output = template


### PR DESCRIPTION
Before this patch, it would use the full text of the template output as the hash value.

My reason for wanting this is to avoid the CLI spamming me with the full text from logging.info()

Pro for this is that we end up with uniform hash values that we can use as keys, I guess, and that we never have to worry about hash spam from custom functions.

Con is that if we make a custom function it's nice to have a place to debug it.  So we could just change the default hash, but not re-hash custom hash functions, and also change the logging not to spam.

I have no opinion other than to want to quiet the logging to console.