### PR TITLE
carthage.vault: Add support for Vault KVv2

### DIFF
--- a/carthage/vault/__init__.py
+++ b/carthage/vault/__init__.py
@@ -198,6 +198,18 @@ class VaultConfigPlugin(ConfigLookupPlugin):
         secret, sep, field = selector.partition(':')
         if field == "":
             raise SyntaxError("The vault plugin requires a field")
+        if secret == "v2":
+            try:
+                mount, secret, field = field.split(":")
+            except ValueError: pass
+            if "mount" not in locals():
+                raise SyntaxError(
+                    f"Found vault plugin prefix \"v2\" and expected"
+                    f" mount:secret:field\" but instead found \"{field}\"."
+                )
+            result = client.secrets.kv.v2.read_secret(secret, mount)["data"]["data"][field]
+            return result
+
         result = client.read(secret)
         return result['data'][field]
 

--- a/carthage/vault/__init__.py
+++ b/carthage/vault/__init__.py
@@ -201,12 +201,11 @@ class VaultConfigPlugin(ConfigLookupPlugin):
         if secret == "v2":
             try:
                 mount, secret, field = field.split(":")
-            except ValueError: pass
-            if "mount" not in locals():
+            except ValueError:
                 raise SyntaxError(
                     f"Found vault plugin prefix \"v2\" and expected"
                     f" mount:secret:field\" but instead found \"{field}\"."
-                )
+                ) from None
             result = client.secrets.kv.v2.read_secret(secret, mount)["data"]["data"][field]
             return result
 


### PR DESCRIPTION
    Previously carthage.vault.VaultConfigPlugin called the
    hvac.Client.read function which uses the KVv1 endpoint.

    KVv2 or KVv1 secrets may now be specified in the config section as follows:

    ```yaml
    config:
      some_v1_secret: "{vault:path/to/secret:field}"
      some_v2_secret: "{vault:v2:some_mountpoint:path/to/v2_secret:field}"
    ```