### PR TITLE
Fix typos

### DIFF
--- a/carthage/modeling/decorators.py
+++ b/carthage/modeling/decorators.py
@@ -255,8 +255,8 @@ class MachineMixin(ModelingDecoratorWrapper):
         self.name = name
 
     def handle(self, cls, ns, k, state):
-        super().handle(cls, ns, k. state)
-        state.flags &= ~(NSFlags.inject_by_name | NsFlags.inject_by_class | NSFlags.instantiate_on_access)
+        super().handle(cls, ns, k, state)
+        state.flags &= ~(NSFlags.inject_by_name | NSFlags.inject_by_class | NSFlags.instantiate_on_access)
         ns.to_inject[InjectionKey(MachineMixin,
                                   name=self.name)] = (
                                       dependency_quote(state.value), state.injection_options)


### PR DESCRIPTION
Noticed these typos while reading through source looking at other things so I wrote a test layout to cause the error.

```
  File "/home/srak/projects/carthage/carthage/modeling/decorators.py", line 258, in handle
    super().handle(cls, ns, k. state)
                            ^^^^^^^^
AttributeError: 'str' object has no attribute 'state'
```

After fixing the above error another error was raised:

```
File "/home/srak/projects/carthage/carthage/modeling/decorators.py", line 259, in handle
    state.flags &= ~(NSFlags.inject_by_name | NsFlags.inject_by_class | NSFlags.instantiate_on_access)
                                              ^^^^^^^
NameError: name 'NsFlags' is not defined. Did you mean: 'NSFlags'?
```

The below code will cause these errors to be raised:
```
class Layout(CarthageLayout):
    
    layout_name = "test"

    domain = "somedomain.net"

    add_provider(machine_implementation_key, dependency_quote(BareMetalMachine))

    @machine_mixin(name="proxy")
    class nginx_install_mixin(MachineModel):
        class nginx_customization(MachineCustomization):

            @setup_task("install nginx")
            async def install_nginx(self):
                print("installing nginx")
                return "nginx was installed"

            @install_nginx.check_completed()
            async def install_nginx(self):
                return True


    class proxy(MachineModel):
        name = "proxy"
```