### PR TITLE
Setup task dependencies

### DIFF
--- a/tests/test_setup_tasks.py
+++ b/tests/test_setup_tasks.py
@@ -268,6 +268,7 @@ async def test_setup_task_context(ainjector):
             assert isinstance(ctx, SetupTaskContext)
             assert ctx.instance is self
             assert ctx.parent.key is InjectionKey(ContextTest)
+            assert not isinstance(ctx.parent, SetupTaskContext)
             called = 1
 
     ainjector.add_provider(ContextTest)

--- a/tests/test_setup_tasks.py
+++ b/tests/test_setup_tasks.py
@@ -155,7 +155,7 @@ async def test_failure_forces_rerun(ainjector):
     o = await ainjector(c)
     assert called == 1
     with pytest.raises(RuntimeError):
-        o.setup_test_error_explicit()
+        await o.setup_test_error_explicit()
     assert called == 2
     should_fail = False
     await ainjector(c)
@@ -221,7 +221,7 @@ async def test_hash_func(ainjector):
             return fake_hash
     o = await ainjector(c)
     test_hash_run = 0
-    o.test_hash()
+    await o.test_hash()
     assert test_hash_run == 1
     await o.run_setup_tasks()
     assert test_hash_run == 1


### PR DESCRIPTION
Add support for depending on some system or service being ready.  This is different than depending on a setup_task being run, because the task might have been run a while ago and the system shut down since then.
