### PR TITLE
Add proper whitespace for package descriptions

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -6,20 +6,19 @@ Build-Depends: debhelper-compat (= 13), dh-python, python3-all (>= 3.5), python3
 Standards-Version: 3.9.6
 X-Python3-Version: >= 3.11
 
-
 Package: python3-carthage
 Architecture: all
 Multi-Arch: foreign
 Depends: ${misc:Depends}, ${python3:Depends}, socat, systemd-container, python3-mako, bridge-utils, python3-yaml, python3-pyvmomi, python3-sh, sshfs, python3-lmdb
 Recommends: python3-hadron-inventory-admin, libvirt-clients, hadron-entanglement-cli (>= 0.10~), qemu-utils, fai-setup-storage
 Description: full-stack infrastructure-as-code framework in python 3
-Carthage is an infrastructure-as-code (IaC) framework. Carthage
+ Carthage is an infrastructure-as-code (IaC) framework. Carthage
  provides models for infrastructure concepts such as machines,
  networks, and domains or groups of machines. There are concrete
  implementations of these models including containers and virtual
  machines.
-.
-Carthage allows experts to quickly construct infrastructure from a
+ .
+ Carthage allows experts to quickly construct infrastructure from a
  Carthage layout. Infrastructure can be real, virtual, or a
  mixture.  Often the same layout is used to produce both real and
  virtual infrastructure.
@@ -30,30 +29,29 @@ Architecture: all
 Multi-Arch: foreign
 Depends: python3-carthage(= ${binary:Version}), ${python3:Depends}
 Description: core CLI commands for the Carthage infrastructure-as-code framework
-Carthage is an infrastructure-as-code (IaC) framework. Carthage
+ Carthage is an infrastructure-as-code (IaC) framework. Carthage
  provides models for infrastructure concepts such as machines,
  networks, and domains or groups of machines. There are concrete
  implementations of these models including containers and virtual
  machines.
-.
-Carthage allows experts to quickly construct infrastructure from a
+ .
+ Carthage allows experts to quickly construct infrastructure from a
  Carthage layout. Infrastructure can be real, virtual, or a
  mixture.  Often the same layout is used to produce both real and
  virtual infrastructure.
-
 
 Package: hadron-carthage
 Architecture: all
 Depends: hadron-carthage-cli (= ${binary:Version}), hadron-container-image, hadron-installer-direct, qemu-kvm, ovmf, libvirt-daemon-system
 Multi-Arch: foreign
 Description: full deployment of the Carthage infrastructure-as-code framework
-Carthage is an infrastructure-as-code (IaC) framework. Carthage
+ Carthage is an infrastructure-as-code (IaC) framework. Carthage
  provides models for infrastructure concepts such as machines,
  networks, and domains or groups of machines. There are concrete
  implementations of these models including containers and virtual
  machines.
-.
-Carthage allows experts to quickly construct infrastructure from a
+ .
+ Carthage allows experts to quickly construct infrastructure from a
  Carthage layout. Infrastructure can be real, virtual, or a
  mixture.  Often the same layout is used to produce both real and
  virtual infrastructure.


### PR DESCRIPTION
I haven't tested this recently but I'm pretty sure it looks right