### PR TITLE
Breaking API Change: reorganize Carthage directory structure

### DIFF
--- a/carthage-resource-agent
+++ b/carthage-resource-agent
@@ -89,7 +89,7 @@ async def start(config, machines):
     layout = await get_layout(config)
     ainjector = layout.ainjector
     config_layout = await ainjector(ConfigLayout)
-    async with file_locked(Path(config_layout.output_dir)/"generation_lock"):
+    async with file_locked(Path(config_layout.cache_dir)/"generation_lock"):
         await layout.generate()
     models = await get_machines(layout, machines)
     import carthage_base.hosted
@@ -118,7 +118,7 @@ async def stop(config, machines):
         return ocf.OCF_ERR_UNIMPLEMENTED
     ainjector = layout.ainjector
     config_layout = await ainjector(ConfigLayout)
-    async with file_locked(Path(config_layout.output_dir)/"generation_lock"):
+    async with file_locked(Path(config_layout.cache_dir)/"generation_lock"):
         await layout.resolve_networking()
     models = await get_machines(layout, machines)
     for m in reversed(models):

--- a/carthage/__init__.py
+++ b/carthage/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2018, 2019, 2020, 2021, 2023, 2024, Hadron Industries, Inc.
+# Copyright (C) 2018, 2019, 2020, 2021, 2023, 2024, 2025, Hadron Industries, Inc.
 # Carthage is free software; you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License version 3
 # as published by the Free Software Foundation. It is distributed
@@ -35,10 +35,11 @@ __all__ += ['persistent_seed_path']
 
 from . import deployment
 from .deployment import  (
+    auto_deploy_policy,
     find_deployables, DeployableFinder,
     find_orphan_deployables,
     run_deployment, run_deployment_destroy, find_deployable, destroy_policy, DeletionPolicy)
-__all__ += ['find_deployable', 'find_deployables', 'DeployableFinder',
+__all__ += ['auto_deploy_policy', 'find_deployable', 'find_deployables', 'DeployableFinder',
             'find_orphan_deployables',
             'run_deployment', 'run_deployment_destroy',
             'destroy_policy', 'DeletionPolicy']

--- a/carthage/config/base.py
+++ b/carthage/config/base.py
@@ -27,8 +27,9 @@ class BaseSchema(ConfigSchema, prefix=""):
 
     base_dir: ConfigPath = "~/.carthage"
     checkout_dir: ConfigPath = "{base_dir}/checkout"
-    output_dir: ConfigPath = "{base_dir}/output"
+    cache_dir:ConfigPath = '{base_dir}/cache'
     image_dir: ConfigPath = "{base_dir}"
+    log_dir:ConfigPath = '{base_dir}/log'
     vm_image_dir: ConfigPath = "{base_dir}/vm"
     state_dir: ConfigPath = "{base_dir}/state"
     #: Directory for local ephemeral state like ssh_agent sockets

--- a/carthage/container.py
+++ b/carthage/container.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2018, 2019, 2020, 2021, 2022, Hadron Industries, Inc.
+# Copyright (C) 2018, 2019, 2020, 2021, 2022, 2025, Hadron Industries, Inc.
 # Carthage is free software; you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License version 3
 # as published by the Free Software Foundation. It is distributed
@@ -64,6 +64,7 @@ class Container(Machine, SetupTaskMixin):
             vol = await self.ainjector(ContainerVolume,
                                        clone_from=self.image,
                                        name="containers/" + self.name)
+            self.clear_stamps_and_cache()
             self.injector.add_provider(container_volume, vol)
         self.volume = vol
         await self.resolve_networking()

--- a/carthage/container.py
+++ b/carthage/container.py
@@ -80,11 +80,8 @@ class Container(Machine, SetupTaskMixin):
         return self.running
 
     @memoproperty
-    def stamp_path(self):
-        if self.volume is None:
-            raise RuntimeError('Volume not yet created')
-        return self.volume.path
-
+    def stamp_subdir(self):
+        return f'nspawn/{self.name}'
     async def do_network_config(self, networking):
         if networking and self.network_links:
             namespace = carthage.network.NetworkNamespace(self.full_name, self.network_links)

--- a/carthage/local.py
+++ b/carthage/local.py
@@ -76,8 +76,8 @@ class LocalMachine(LocalMachineMixin, Machine, SetupTaskMixin, AsyncInjectable):
         return True
 
     @memoproperty
-    def stamp_path(self):
-        return Path(self.config_layout.state_dir + "/localhost")
+    def stamp_subdir(self):
+        return 'localhost_machine'
 
 
 def process_local_network_config(model):

--- a/carthage/machine.py
+++ b/carthage/machine.py
@@ -752,7 +752,7 @@ class BaseCustomization(SetupTaskMixin, AsyncInjectable):
             pass
 
     @property
-    def stamp_path(self):
+    def stamp_subdir(self):
         return self.host.stamp_path
 
     def create_stamp(self, stamp, contents):
@@ -980,8 +980,8 @@ class BareMetalMachine(Machine, SetupTaskMixin, AsyncInjectable):
         return True
 
     @memoproperty
-    def stamp_path(self):
-        return Path(f'{self.config_layout.state_dir}/machines/{self.name}')
+    def stamp_subdir(self):
+        return 'machines/'+self.name
 
 
 def disk_config_from_model(model, default_disk_config):

--- a/carthage/modeling/ansible.py
+++ b/carthage/modeling/ansible.py
@@ -51,7 +51,7 @@ class AnsibleModelMixin(InjectableModel, AsyncInjectable):
         self.injector.add_provider(
             InjectionKey(AnsibleInventory),
             when_needed(AnsibleInventory,
-                        destination=self.config_layout.output_dir + "/inventory.yml"))
+                        destination=self.config_layout.cache_dir + "/inventory.yml"))
         enable_modeling_ansible(self.injector)
 
     async def generate(self):

--- a/carthage/modeling/base.py
+++ b/carthage/modeling/base.py
@@ -17,7 +17,7 @@ from .implementation import *
 from .decorators import *
 from carthage.dependency_injection import *  # type: ignore
 from carthage.utils import when_needed, memoproperty
-from carthage import ConfigLayout, SetupTaskMixin
+from carthage import ConfigLayout, SetupTaskMixin, PathMixin
 import carthage.kvstore
 import carthage.network
 import carthage.machine
@@ -348,7 +348,7 @@ class MachineModelMixin:
 @inject_autokwargs(
     config_layout=ConfigLayout,
                    )
-class MachineModel(ModelContainer, carthage.machine.AbstractMachineModel, metaclass=MachineModelType, template=True):
+class MachineModel(ModelContainer, carthage.machine.AbstractMachineModel, PathMixin, metaclass=MachineModelType, template=True):
 
     '''
 
@@ -469,10 +469,8 @@ Every :class:`carthage.machine.BaseCustomization` (including MachineCustomizatio
         return res
 
     @memoproperty
-    def stamp_path(self):
-        path = self.config_layout.output_dir + f"/hosts/{self.name}"
-        os.makedirs(path, exist_ok=True)
-        return Path(path)
+    def stamp_subdir(self):
+        return 'machine_model/'+self.name
 
     async def resolve_networking(self, *args, **kwargs):
         '''
@@ -651,9 +649,9 @@ class ModelTasks(ModelContainer, SetupTaskMixin, AsyncInjectable):
         return InjectionKey(ModelTasks, name=name)
 
     @memoproperty
-    def stamp_path(self):
+    def stamp_subdir(self):
         name = getattr(self.__class__, 'name', self.__class__.__name__)
-        return Path(self.config_layout.output_dir) / name
+        return name
 
 
 __all__ += ['ModelTasks']

--- a/carthage/pki.py
+++ b/carthage/pki.py
@@ -49,8 +49,8 @@ def ca_file(certificates, *,
     '''
     assert name, 'Currently support for name=None is unimplemented; probably the right approach is to hash the certificates.'
     config = injector(ConfigLayout)
-    output_dir = pathlib.Path(config.output_dir)
-    truststores = output_dir/'truststores'
+    cache_dir = pathlib.Path(config.cache_dir)
+    truststores = cache_dir/'truststores'
     truststores.mkdir(parents=True, exist_ok=True)
     name = name.replace('/', '_')
     ca_path = truststores/name

--- a/carthage/podman/base.py
+++ b/carthage/podman/base.py
@@ -344,7 +344,8 @@ An OCI container implemented using ``podman``.  While it is possible to set up a
         self.container_info = containers[0]
         ports = self.container_info['NetworkSettings']['Ports']
         if not hasattr(self, 'ssh_port') and '22/tcp' in ports:
-            self.ssh_port = ports['22/tcp'][0]['HostPort']
+            if ports['22/tcp']:
+                self.ssh_port = ports['22/tcp'][0]['HostPort']
         self.id = self.container_info['Id']
         self.running = self.container_info['State']['Running']
         try:

--- a/carthage/resources/ansible-chroot-helper
+++ b/carthage/resources/ansible-chroot-helper
@@ -13,7 +13,9 @@ async def run(ainjector):
     cl = await ainjector(ConfigLayout)
     cl.container_prefix = ""
     ainjector.add_provider(container_volume, await ainjector(ContainerVolume, container_dir))
-    container = await ainjector(Container, name=name, image=None)
+    with instantiation_not_ready():
+        container = await ainjector(Container, name=name, image=None)
+        await container.is_machine_running()
     return container.shell("/bin/sh", "-c", sys.argv[4], _fg=True)
 
 if __name__ == "__main__":

--- a/carthage/ssh.py
+++ b/carthage/ssh.py
@@ -107,6 +107,10 @@ class SshKey(AsyncInjectable, SetupTaskMixin):
         return Path(self.config_layout.state_dir)
 
     @memoproperty
+    def state_path(self):
+        return Path(self.config_layout.state_dir)
+    @memoproperty
+
     def ssh(self):
         return sh.ssh.bake(_env=self.agent.agent_environ)
 

--- a/carthage/vm.py
+++ b/carthage/vm.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2018, 2019, 2020, 2021, 2024, Hadron Industries, Inc.
+# Copyright (C) 2018, 2019, 2020, 2021, 2024, 2025, Hadron Industries, Inc.
 # Carthage is free software; you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License version 3
 # as published by the Free Software Foundation. It is distributed
@@ -327,12 +327,10 @@ class Vm(Machine, SetupTaskMixin):
             await asyncio.sleep(3)
 
     @memoproperty
-    def stamp_path(self):
+    def stamp_subdir(self):
         if self.volume:
-            return Path(self.volume.stamp_path)
-        res = Path(self.config_layout.output_dir)/'libvirt_stamps'/self.name
-        res.mkdir(parents=True, exist_ok=True)
-        return res
+            return self.volume.stamp_subdir
+        return 'libvirt/'+self.name
 
     async def dynamic_dependencies(self):
         await self.gen_volume()

--- a/carthage/vmware/inventory.py
+++ b/carthage/vmware/inventory.py
@@ -60,12 +60,9 @@ class VmwareStampable(SetupTaskMixin, AsyncInjectable):
         raise NotImplementedError(type(self))
 
     @memoproperty
-    def stamp_path(self):
-        p = self.config_layout.state_dir
-        p = os.path.join(p, "vmware_stamps", self.stamp_type)
+    def stamp_subdir(self):
+        p = os.path.join("vmware_stamps", self.stamp_type)
         p = os.path.join(p, *self.stamp_descriptor.lstrip('/').split('/'))
-        p += ".stamps"
-        os.makedirs(p, exist_ok=True)
         return p
 
 

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -108,7 +108,7 @@ class LayoutTest(ModelGroup):
 async def test_ansible_and_modeling(test_ainjector, config):
     ainjector = test_ainjector
     layout = await ainjector(LayoutTest)
-    layout.injector.add_provider(when_needed(AnsibleInventory, config.state_dir + "/ansible.yml"))
+    layout.injector.add_provider(when_needed(AnsibleInventory, config.cache_dir + "/ansible.yml"))
     ainjector.add_provider(InjectionKey("layout"), layout)  # So it is cleaned up
     await ainjector.get_instance_async(carthage.ssh.SshKey)
     await layout.generate()

--- a/tests/test_setup_tasks.py
+++ b/tests/test_setup_tasks.py
@@ -31,6 +31,7 @@ def ainjector(ainjector):
     config = ainjector.injector(carthage.ConfigLayout)
     config.state_dir = state_dir
     os.makedirs(state_dir, exist_ok=True)
+    config.cache_dir = os.path.join(state_dir, 'cache')
     yield ainjector
     shutil.rmtree(state_dir, ignore_errors=True)
 


### PR DESCRIPTION
We create three classes of directories off PathMixin including SetupTaskMixin 

* stamp_path (off config/cache_dir): where completion stamps and other items than can be regenerated are
* state_path (off config.state_dir) where long-term state like tokens or keys are stored
* log_path (off config.log_dir) where logs are stored

All these sub directories have the same structure based off `stamp_subdir`.

PathMixin also always has a config_layout, which never drops a ConfigLayout into the injector.
