### PR TITLE
Handle empty or invalid JSON from QEMU agent

### DIFF
--- a/carthage/vm.py
+++ b/carthage/vm.py
@@ -306,8 +306,12 @@ class Vm(Machine, SetupTaskMixin):
                     raise
                 await asyncio.sleep(5)
                 continue
-
-            js_res = json.loads(res.stdout)
+            try:
+                js_res = json.loads(res.stdout)
+            except json.JSONDecodeError:
+                # Occasionally the qemu agent returns empty or invalid JSON briefly after starting a VM
+                await asyncio.sleep(3)
+                continue
             for item in js_res['return']:
                 if item['name'] == 'lo':
                     continue


### PR DESCRIPTION
- When starting a large number of libvirt VMs simultaneously, the QEMU agent may return empty or invalid JSON for the first few seconds after a VM is started
- Add a catch for JSONDecodeError to have _find_ip_address retry after a brief timeout