### PR TITLE
Refactor SshAgent

### DIFF
--- a/carthage/ansible.py
+++ b/carthage/ansible.py
@@ -510,7 +510,10 @@ def write_config(config_dir, inventory,
                  ansible_config):
     private_key = ""
     if ssh_key:
-        ssh_agent = ssh_key.agent
+        if ssh_key.agent:
+            ssh_agent = ssh_key.agent
+        else:
+            ssh_key.add_to_agent(ssh_agent)
         private_key = f"private_key_file = {ssh_key.key_path}"
     if not log:
         stdout_str = "stdout_callback = json"

--- a/carthage/config/base.py
+++ b/carthage/config/base.py
@@ -43,7 +43,7 @@ class BaseSchema(ConfigSchema, prefix=""):
 
     #: If true, keep the ssh agent in the environment potentially
     # using production ssh keys rather than starting our own
-    production_ssh_agent: bool = False
+    production_ssh_agent: bool = True
     #: Path to  a checkout of hadron_operations
     hadron_operations: ConfigPath
     delete_volumes: bool = False


### PR DESCRIPTION
We want to be able to add_provider an SshKey deeper in the injector hierarchy than at base_injector. That is tricky because SshAgent depends on SshKey and for a variety of reasons we want SshAgent to be singular.

* SshAgent no longer depends on an SshKey

* SshMixin.ssh will add a key to an agent

* SshMixin rsync: handle key.agent being None

* SshKey: take an optional key_path.

* ansible.write_config: Handle case where ssh_key does not yet have an assigned agent