### PR TITLE
Fixes carthage-runner ignoring --no-pull-plugins

### DIFF
--- a/carthage/plugins.py
+++ b/carthage/plugins.py
@@ -311,7 +311,7 @@ def handle_git_url(spec, injector):
                 sh.git('switch', branch, _cwd=dest)
                 
         logger.info('Pulling %s', dest)
-        sh.git('pull', '-q', '--ff-only', parsed.geturl(), _cwd=dest)
+        sh.git('pull', '-q', '--depth=1', '--ff-only', parsed.geturl(), _cwd=dest)
         return dest
     elif dest.exists():
         return dest

--- a/carthage/utils.py
+++ b/carthage/utils.py
@@ -279,10 +279,10 @@ def carthage_main_setup(parser=None, unknown_ok=False, ignore_import_errors=Fals
         logging.getLogger('urllib3.connectionpool').propagate = False
     if args.default_config:
         load_default_config(config)
-    for f in args.config:
-        config.load_yaml(f, ignore_import_errors=ignore_import_errors)
     if args.pull_plugins is not None:
         config.pull_plugins = args.pull_plugins
+    for f in args.config:
+        config.load_yaml(f, ignore_import_errors=ignore_import_errors)
     for p in args.plugins:
         base_injector(load_plugin, p, ignore_import_errors=ignore_import_errors)
     if args.tasks_verbose:


### PR DESCRIPTION
Reorder setting config.pull_plugins before handle_git_url is actually called.
Clone with --depth=1 for speed.