### PR TITLE
Allow sh kwargs to pass through container_exec / container_host.podman

### DIFF
--- a/carthage/podman/base.py
+++ b/carthage/podman/base.py
@@ -544,7 +544,7 @@ An OCI container implemented using ``podman``.  While it is possible to set up a
             self.running = False
             await super().stop_machine()
 
-    def container_exec(self, *args, _user=None, _fg=False):
+    def container_exec(self, *args, _user=None, _fg=False, **kwargs):
         '''
 Execute a command in a running container and return stdout.  This function intentionally has a differentname than :meth:`carthage.container.Container.container_command` because that method does not expect the container to be running.
 '''
@@ -564,6 +564,7 @@ Execute a command in a running container and return stdout.  This function inten
             self.full_name,
             *args,
             _log=False, _fg=_fg,
+            **kwargs,
             )
         return result
 

--- a/carthage/podman/container_host.py
+++ b/carthage/podman/container_host.py
@@ -41,7 +41,7 @@ class PodmanContainerHost(AsyncInjectable):
         return self.injector.get_instance(InjectionKey("podman_log", _optional=True))
 
     def podman(self, *args,
-               _bg=True, _bg_exc=True):
+               _bg=True, _bg_exc=True, **kwargs):
         raise NotImplementedError
 
     def podman_nosocket(self, *args, **kwargs):
@@ -120,7 +120,7 @@ class LocalPodmanContainerHost(PodmanContainerHost):
             pass  # Perhaps we should unmount, but we'd need a refcount to do that.
 
     async def podman(self, *args,
-               _bg=True, _bg_exc=False, _log=True, _fg=False):
+               _bg=True, _bg_exc=False, _log=True, _fg=False, **kwargs):
         options = {}
         if _log and self.podman_log:
             options['_out']=str(self.podman_log)
@@ -128,7 +128,8 @@ class LocalPodmanContainerHost(PodmanContainerHost):
         result = sh.podman(
             *args,
             _fg=_fg,
-            **options)
+            **options,
+            **kwargs)
         if not _fg:
             return await result
         return result


### PR DESCRIPTION
Allow passing of kwargs to sh like

```
res = await self.host.container_exec(["/usr/bin/false"], _ok_code=[0, 1])
```

in order to suppress raises from sh.Command