### PR TITLE
Add a new libvirtd Carthage image

### DIFF
--- a/oci_images/bridge.conf
+++ b/oci_images/bridge.conf
@@ -1,0 +1,1 @@
+allow virbr0

--- a/oci_images/disable_setgroups.c
+++ b/oci_images/disable_setgroups.c
@@ -1,0 +1,7 @@
+#define _GNU_SOURCE
+#include <sys/types.h>
+#include <errno.h>
+
+int setgroups(size_t size, const gid_t *list) {
+    return 0;
+}

--- a/oci_images/libvirtd.conf
+++ b/oci_images/libvirtd.conf
@@ -1,0 +1,3 @@
+[Service]
+ExecStart=
+ExecStart=LD_PRELOAD=/usr/local/lib/disable_setgroups.o /usr/sbin/libvirtd $LIBVIRTD_ARGS

--- a/oci_images/python/layout.py
+++ b/oci_images/python/layout.py
@@ -30,20 +30,20 @@ class layout(CarthageLayout):
     add_provider(ConfigLayout)
 
     add_provider(OciMount(destination='/var/lib/apt/lists'))
-    
+
     @inject(base_image=None)
     class VolumeAccess(PodmanImageModel):
         '''
         The Debian distribution we are using with an sftp server installed. Used by the podman plugin to gain sftp access to volumes.
         '''
-    
+
         oci_image_tag = 'ghcr.io/hadron/carthage_volume_access:latest'
         base_image = 'debian:trixie'
         add_provider(podman_push_images, True)
 
         class InstallSftpServer(ContainerCustomization):
             install_sftp = install_stage1_packages_task(['openssh-sftp-server'], install_recommends=False)
-        
+
     @inject(base_image=None)
     class OurBaseImage(PodmanImageModel):
         name = 'base-carthage'
@@ -76,3 +76,47 @@ class layout(CarthageLayout):
                 await self.run_command("/bin/systemctl", "mask", "console-getty", )
                 await  self.run_command("/bin/systemctl", "enable", "console")
 
+    class CarthageLibvirtImage(PodmanImageModel):
+        base_image = injector_access('CarthageImage')
+        oci_image_tag = 'ghcr.io/hadron/carthage-libvirt:latest'
+        oci_image_command = ['/sbin/init']
+
+        class customize_for_oci_container(DebianContainerCustomizations):
+
+            @setup_task("Configure qemu user and group")
+            async def configure_qemu_user(self):
+                await self.run_command("/usr/bin/sed", "-i", """$a'user = "root"\ngroup = "root"\nremember_owner = 0\n'""", self.path/"etc/libvirt/qemu.conf")
+
+            @setup_task("Configure qemu to allow access to default network")
+            async def configure_qemu_default_network(self):
+                qemu_path = self.path/"etc/qemu"
+                qemu_path.mkdir(parents=True, exist_ok=True)
+                shutil.copyfile(_dir/"bridge.conf", qemu_path/"bridge.conf")
+
+
+            @setup_task("Install virt-manager")
+            async def install_virt_manager(self):
+                bind_args = bind_args_for_mirror(self.config_layout.debian.stage1_mirror)
+                async with use_stage1_mirror(self):
+                    await self.container_command(*bind_args,
+                                                "apt", "update")
+                    await self.container_command(*bind_args,
+                                                "apt-get", "-y", "install", "virt-manager")
+
+                # Enable default network to avoid conflict with pasta
+                await self.container_command("/usr/bin/virsh", "net-autostart", "default")
+                await self.container_command("/usr/bin/virsh", "net-start", "default")
+
+
+        class customize_for_oci_fs(FilesystemCustomization):
+
+            @setup_task("Compile setgroups LD_PRELOAD library")
+            async def compile_segroups_ld_preload(self):
+                shutil.copyfile(_dir/"disable_setgroups.c", self.path/"usr/local/src")
+                await self.run_command("/usr/bin/gcc", "-c", "-o", self.path/"usr/local/lib", self.path/"usr/local/src/disable_setgroups.c")
+
+            @setup_task("Override libvirtd systemd service with setgroups disabled")
+            async def install_config(self):
+                libvirtd_override_path = self.path/"etc/systemd/system/libvirtd.service.d"
+                libvirtd_override_path.mkdir(parents=True, exist_ok=True)
+                shutil.copyfile(_dir/"libvirtd.conf", libvirtd_override_path/"override.conf")


### PR DESCRIPTION
feat: Adds a new CarthageLibvirtImage layout to oci_images that supports using libvirtd in a container even if the host does not have libvirtd installed or configured